### PR TITLE
ci: grant pull-requests write permission to code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
The action needs write access to post review comments back to the PR.
With only `read`, the workflow completes silently — Claude runs but
has no way to surface its findings.