### PR TITLE
ci: grant write permissions and fix allowed tools for Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,14 +22,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
@@ -39,6 +37,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: --max-turns 5 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
+          claude_args: "--max-turns 5"
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Both workflows had read-only permissions for `pull-requests` and `issues`,
which prevented Claude from posting review comments. The code review workflow
also lacked `claude_args` entirely, so no tools were explicitly allowed —
the single `permission_denials_count: 1` in the run logs pointed to Claude
being blocked when trying to post its review.

Permissions are upgraded to write on both workflows. The code review workflow
now has a scoped `--allowedTools` list covering the minimum needed: reading
the diff and PR, posting top-level comments via `gh`, and inline annotations
via the action's built-in MCP inline comment server. Max turns is capped at 5
to keep costs in check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)