### PR TITLE
ci: simplify code-review prompt and add show_full_output

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,8 +36,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: --max-turns 5 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: '/code-review --comment'
+          show_full_output: true
+          claude_args: --max-turns 10
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Simplifies the `prompt` to `/code-review --comment` — the plugin handles tool permissions itself, no need to pass `--allowedTools` manually
- Adds `show_full_output: true` for better debugging of workflow runs
- Sets `--max-turns 10` to give the 4 parallel review agents enough room

## Test plan
- [ ] Workflow triggers on this PR itself
- [ ] Run completes with `permission_denials_count == 0`
- [ ] Claude posts a review comment on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)