### PR TITLE
ci: use official marketplace for code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,8 +34,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          plugins: 'code-review@claude-plugins-official'
           prompt: '/code-review --comment'
           show_full_output: true
           claude_args: --max-turns 10


### PR DESCRIPTION
## Summary
- Remove `plugin_marketplaces` — `claude-plugins-official` is auto-available and doesn't need to be added manually
- Switch `plugins` from `code-review@claude-code-plugins` to `code-review@claude-plugins-official`

## Test plan
- [ ] Workflow triggers on this PR
- [ ] Run completes without "unknown skill" error
- [ ] `permission_denials_count == 0`
- [ ] Claude posts a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)