### PR TITLE
ci: explicitly register official marketplace for code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           plugins: 'code-review@claude-plugins-official'
           prompt: '/code-review --comment'
           show_full_output: true


### PR DESCRIPTION
Without explicitly specifying `plugin_marketplaces`, CI was failing with `Plugin "code-review" not found in marketplace "claude-plugins-official"` because the official marketplace isn't auto-available in the GitHub Actions runner (unlike locally).

Adding `plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'` so CI can resolve `code-review@claude-plugins-official`.