### PR TITLE
ci: use namespaced prompt for code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           plugins: 'code-review@claude-plugins-official'
-          prompt: '/code-review --comment'
+          prompt: '/code-review:code-review --comment'
           show_full_output: true
           claude_args: --max-turns 10
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
When invoking a plugin skill, Claude Code requires the fully-qualified `plugin:command` form (`/code-review:code-review`) rather than the bare `/code-review`.

Without the namespace, the skill lookup fails silently and the workflow produces no review. Observed the correct invocation working locally via the Claude Code CLI before applying the fix to the workflow.