### PR TITLE
Fix code review workflow targeting wrong PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
           plugins: 'code-review@claude-plugins-official'
-          prompt: '/code-review:code-review --comment'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            /code-review:code-review --comment
           show_full_output: true
           claude_args: --max-turns 10
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

- **Root cause:** The `code-review` skill had no context about which repo or PR to target, causing it to review the wrong PR.
- **Fix:** Inject `REPO` and `PR NUMBER` variables at the top of the prompt (sourced from `github.repository` and `github.event.pull_request.number`) so the skill always operates on the correct PR.

## Test plan

- [ ] CI triggers the code-review workflow on this PR
- [ ] Confirm the code-review action comments on this PR (not a different one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)