### PR TITLE
ci: allow Claude tools to run without approval in CI

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
           plugins: 'code-review@claude-plugins-official'
           prompt: '/code-review:code-review --comment'
           show_full_output: true
-          claude_args: --max-turns 10
+          claude_args: --max-turns 10 --dangerously-skip-permissions
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 5"
+          claude_args: "--max-turns 5 --dangerously-skip-permissions"
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Without `--dangerously-skip-permissions`, Claude Code pauses on every tool call waiting for interactive approval — which never comes in a headless CI environment. Both workflows were effectively non-functional as a result.

This flag is safe here because the workflows are already gated by GitHub's event model and the OAuth token's own permission scopes cap what Claude can actually do.