### PR TITLE
ci: replace heavy plugin-based PR review with lightweight prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,48 +1,35 @@
-name: Claude Code Review
-
+name: Claude Auto Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, synchronize]
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+  review:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-plugins-official.git'
-          plugins: 'code-review@claude-plugins-official'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            /code-review:code-review --comment
-          show_full_output: true
-          claude_args: --max-turns 10 --dangerously-skip-permissions
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+            Review this PR for a Kotlin Multiplatform + Compose Multiplatform app. Focus on:
+            - Code quality and correctness
+            - KMP/Compose best practices
+            - Potential bugs or issues
+            - CLAUDE.md conventions (no comments, UUIDs for PKs, IO dispatcher for DB, etc.)
 
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) for specific code issues.
+            Only post GitHub comments — don't output review text as messages.
+          claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
The previous workflow used the `code-review` plugin which orchestrated multiple specialised sub-agents — overkill for a small solo project. The new approach uses a direct prompt with explicitly scoped tools, which is faster, cheaper, and easier to understand and maintain.

Constraints tightened: `--allowedTools` replaces `--dangerously-skip-permissions`. Triggers reduced to `opened`/`synchronize` only — `ready_for_review` dropped because `opened` already fires for draft PRs, so keeping both would trigger a redundant review when a draft is marked ready.

Added `fetch-depth: 1` for a shallow clone — the review only needs the current file state, not the full git history, so this speeds up the checkout step.