### PR TITLE
fix(build): resolve KLIB linkage crash and drop ui-tooling-preview

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
             implementation(libs.compose.material3)
             implementation(libs.compose.ui)
             implementation(libs.compose.components.resources)
-            implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
         }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,20 +1,14 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
 }
 
-configurations.all {
-    exclude(group = "androidx.lifecycle")
-    exclude(group = "androidx.savedstate")
-    exclude(group = "org.jetbrains.compose.annotation-internal")
-    exclude(group = "org.jetbrains.compose.collection-internal")
-    resolutionStrategy.eachDependency {
-        if (requested.group == "org.jetbrains.compose.runtime") {
-            useTarget("androidx.compose.runtime:${requested.name}:${libs.versions.composeRuntime.get()}")
-        }
-    }
-}
+tasks.withType<KotlinCompilationTask<*>>()
+    .matching { it.name.endsWith("KotlinMetadata") }
+    .configureEach { compilerOptions { allWarningsAsErrors = false } }
 
 kotlin {
     compilerOptions {
@@ -34,7 +28,6 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)
             implementation(libs.compose.ui)
@@ -45,6 +38,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.compose.uiTest)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/App.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/App.kt
@@ -13,14 +13,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import org.jetbrains.compose.resources.painterResource
 
 import meal_planner.composeapp.generated.resources.Res
 import meal_planner.composeapp.generated.resources.compose_multiplatform
 
 @Composable
-@Preview
 fun App() {
     MaterialTheme {
         var showContent by remember { mutableStateOf(false) }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/ComposeLayerSmokeTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/ComposeLayerSmokeTest.kt
@@ -1,0 +1,17 @@
+package dev.mirabal.mealplanner
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+class ComposeLayerSmokeTest {
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun composeLayerInitialises() = runComposeUiTest {
+        setContent {
+            MaterialTheme {}
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 androidx-lifecycle = "2.9.6"
 composeMultiplatform = "1.10.0"
-composeRuntime = "1.10.0"
 kotlin = "2.3.0"
 material3 = "1.9.0"
 
@@ -9,12 +8,12 @@ material3 = "1.9.0"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
+compose-uiTest = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", v
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
-compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 compose-uiTest = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
 
 [plugins]


### PR DESCRIPTION
Fix a runtime `IrLinkageError` crash on every app launch and remove a build artefact that inflated the iOS binary.

The crash was caused by `androidx.savedstate` being excluded from the binary. With lifecycle 2.9.6, that library ships
a new multiplatform `SavedState` type called at runtime by `lifecycle-viewmodel-savedstate`. Removing it left an
unresolvable symbol that the Compose hosting view controller hit before the first frame rendered.

The exclusions and resolution overrides in `configurations.all` were originally silencing duplicate KLIB resolver
warnings that `allWarningsAsErrors` promoted to errors. CMP publishes libraries under both `androidx.*` and
`org.jetbrains.*` coordinates; their commonMain KLIBs share `unique_name` values, which the KLIB resolver flags
as duplicates. Their iOS-platform KLIBs have distinct `unique_name`s so both sets coexist without conflict in the
actual binary — the warnings were pure noise.

The fix replaces all exclusions/redirects with a single targeted suppression: `allWarningsAsErrors` is relaxed only
for `*KotlinMetadata` tasks (where the duplicate-name noise originates). All other compilations, including iOS, still
enforce it. `org.jetbrains.compose.runtime` no longer needs an explicit declaration — the real
`androidx.compose.runtime` arrives transitively through other CMP dependencies.

Neither existing CI check caught the crash: `iosSimulatorArm64Test` only exercises pure Kotlin business logic and
never instantiates the Compose layer; `verifyXcodeBuild` compiles and links successfully because Kotlin/Native defers
symbol resolution to runtime, emitting informational hints instead of link errors. A new `ComposeLayerSmokeTest` calls
`runComposeUiTest`, which spins up a real `ComposeHostingViewController` on the iOS simulator — the same code path
that crashed in production. `./gradlew build` now fails without the fix and passes with it.

`ui-tooling-preview` was also removed from `commonMain` in a follow-up: `@Preview` is an IDE-only annotation with no
runtime effect, and shipping `ui-tooling-preview` unnecessarily inflated the iOS framework binary. It was replaced
with `compose-uiTest` in `commonTest` to support the new smoke test.