### PR TITLE
ci: skip builds for markdown and docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,9 @@ name: Claude Auto Review
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `ci.yml` (macOS build) and `claude-code-review.yml` to skip runs when a PR only touches `.md` files or `docs/`
- `claude.yml` is event-driven (@claude mentions) and needs no change

## Verification
This PR itself should produce no CI runs — check the Actions tab after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)