### PR TITLE
docs: switch UI library reference from cupertino to Material3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,7 @@ off, and where they were bought.
 
 - **Language:** Kotlin (no Swift)
 - **Framework:** Kotlin Multiplatform + Compose Multiplatform
-- **UI components:** compose-cupertino (`cupertino-adaptive`) — renders iOS-native Cupertino widgets
-  on iOS, Material3 on Android
+- **UI components:** Compose Material3 (`androidx.compose.material3`)
 - **Storage:** SQLDelight 2.x (local SQLite, no backend)
 - **State management:** AndroidX ViewModel + Kotlin StateFlow
 - **Navigation:** Official CMP Navigation (`org.jetbrains.androidx.navigation:navigation-compose`)


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md` tech stack to reflect the decision to use Compose Material3 instead of compose-cupertino

## Verification
This PR should produce no CI runs (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)