### PR TITLE
chore: codify conventions learned from issue #1 review fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ off, and where they were bought.
   construction (`viewModel { }`) belongs at the wiring layer (`App.kt` or the navigation graph),
   not inside the screen composable.
 - `internal` is for concrete implementations (e.g. `InMemoryItemRepository`). Interfaces and
-  ViewModels that external callers need are public.
+  ViewModels that external callers need are public. The public API surface of a feature package is:
+  the repository *interface*, its factory function (e.g. `fun itemRepository(): ItemRepository` in
+  the interface file), and the ViewModel. The screen composable is `internal`.
 - Single `composeApp` module with `commonMain`, `androidMain`, `iosMain` source sets
 - Platform-specific code is minimal: just `SqlDriver` factory per platform
 - `iosApp/` contains a thin Swift wrapper calling Kotlin's `MainViewController`
@@ -56,7 +58,23 @@ Use `./gradlew build` before committing or after any significant change. Use `./
 - Save state immediately after every user action — no batching writes.
 - Prefer tiny types: wrap domain concepts in `value class` (e.g. `ItemId`, `ItemName`, `CreatedAt`,
   `UpdatedAt`) rather than using raw primitives. This prevents passing values in the wrong order and
-  makes invalid states unrepresentable. No `@JvmInline` — iOS doesn't support it.
+  makes invalid states unrepresentable. No `@JvmInline` — iOS doesn't support it. String-based tiny
+  types must enforce all domain invariants in `init`, e.g.
+  `require(value == value.trim()) { "must be trimmed" }`. Give each tiny type its own `XxxTest`
+  with exhaustive invariant cases (leading space, trailing space, both).
+- StateFlow & ViewModel rules:
+  - Never expose a `MutableStateFlow` directly. Declare `private val _x = MutableStateFlow(...)`
+    and expose `val x: StateFlow<T> = _x.asStateFlow()`.
+  - Share repository flows with `SharingStarted.WhileSubscribed()`. Never use `Eagerly` — it keeps
+    the upstream alive for the full ViewModel lifetime even with no subscribers.
+  - Collect StateFlow in Compose with `collectAsStateWithLifecycle()`, never `collectAsState()`.
+  - Mutate UI state (e.g. clear the text field) only *after* the repository suspend call completes
+    — never before, to avoid silent data loss if the write throws.
+  - Always supply `key = { item.id.value.toString() }` on `LazyColumn`/`LazyRow` items so Compose
+    tracks item identity across recompositions.
+- Before committing, confirm every declared Gradle dependency is actually imported somewhere in
+  source. Remove unused entries. Verify version numbers on Maven Central before pinning new
+  libraries.
 
 ## Testing conventions
 
@@ -64,7 +82,12 @@ Use `./gradlew build` before committing or after any significant change. Use `./
   one. Constructing the expected object causes a compile error when new fields are added, keeping
   tests exhaustive. For unpredictable fields (e.g. generated UUIDs), use the actual value from the
   result: `id = item.id`.
-- Use a `FakeClock` (injectable `Clock` implementation) for deterministic timestamps.
+- Use a `FakeClock` (injectable `Clock` implementation) for deterministic timestamps. Place shared
+  test helpers like `FakeClock` in `commonTest/.../testutil/` as `internal class`. Never inline the
+  same helper in multiple test files.
+- When testing a `WhileSubscribed` StateFlow in `runTest`, activate it with
+  `flow.launchIn(backgroundScope)` and pass an explicit dispatcher:
+  `runTest(UnconfinedTestDispatcher()) { ... }` so `backgroundScope` uses it.
 - Tests live in `commonTest` and run on the iOS simulator via `./gradlew iosSimulatorArm64Test`.
 
 ## Project structure


### PR DESCRIPTION
## Summary

- Six post-review commits on the walking skeleton revealed gaps between what the code required and what CLAUDE.md prescribed
- Each fix is now traced to an explicit rule so future iterations get them right on the first pass

## Rules added

| Area | Rule |
|------|------|
| Architecture | Public API surface = interface + factory fn + ViewModel; screen is `internal` |
| Tiny types | String-based types must enforce invariants in `init`; each gets its own `XxxTest` |
| StateFlow/ViewModel | No raw `MutableStateFlow` exposure; `WhileSubscribed` not `Eagerly`; `collectAsStateWithLifecycle`; clear input after write completes; `LazyColumn` keys |
| Testing | Shared helpers in `testutil/`; `runTest(UnconfinedTestDispatcher())` for `WhileSubscribed` flows |
| Dependencies | Confirm all declared deps are used before committing |

## Test plan

- [ ] Read CLAUDE.md end-to-end and confirm each rule is clear and non-redundant
- [ ] Cross-check: every one of the 6 fix commits (5722bea, c9fb084, 8c8d0c8, 78da434, 124c52e, 28ff0fa) has a corresponding rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)