### PR TITLE
ci: sharpen auto-review prompt to reduce false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,14 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - '.github/workflows/claude-code-review.yml'
+      - '.github/workflows/claude.yml'
   pull_request:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+      - '.github/workflows/claude-code-review.yml'
+      - '.github/workflows/claude.yml'
 
 jobs:
   build:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths-ignore:
-      - '**/*.md'
       - 'docs/**'
 
 jobs:
@@ -26,13 +25,31 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this PR for a Kotlin Multiplatform + Compose Multiplatform app. Focus on:
-            - Code quality and correctness
-            - KMP/Compose best practices
-            - Potential bugs or issues
-            - CLAUDE.md conventions (no comments, UUIDs for PKs, IO dispatcher for DB, etc.)
+            This is a Kotlin Multiplatform + Compose Multiplatform app that targets iOS ONLY.
+            There is no Android production target. Do NOT flag Android-specific issues.
+
+            Before reviewing, read the project conventions with: cat CLAUDE.md
+
+            Review the PR diff and focus ONLY on:
+            - Correctness bugs (logic errors, race conditions, data loss)
+            - KMP/Compose Multiplatform best-practice violations
+            - CLAUDE.md convention violations:
+                - Comments added to code
+                - Non-UUID primary keys
+                - DB operations not on Dispatchers.IO
+                - Domain primitives missing value class wrapping
+                - ViewModel constructed inside a Screen composable
+                - Repository/dependency injected directly into a Screen
+
+            Do NOT flag:
+            - Android-specific APIs, patterns, or lifecycle concerns
+            - Missing @JvmInline (not supported on iOS)
+            - Missing Android instrumented tests
+            - Style nits already covered by the compiler or linter
+
+            If there are no real issues to raise, post nothing.
 
             Use `gh pr comment` for top-level feedback.
             Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) for specific code issues.
-            Only post GitHub comments — don't output review text as messages.
-          claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            Only post GitHub comments — do not output review text as messages.
+          claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cat CLAUDE.md)"


### PR DESCRIPTION
The previous prompt was generic and produced noisy, Android-flavoured
feedback on an iOS-only project. The reviewer had no instruction to read
`CLAUDE.md`, no iOS context, and no silence threshold, so it commented
even when there was nothing worth raising.

Three root causes addressed:

1. No platform context — Claude defaulted to generic KMP advice that
   includes Android lifecycle, `@JvmInline`, and Android test concerns
   that simply do not apply here. The prompt now declares iOS-only
   upfront and lists an explicit "do NOT flag" section.

2. `CLAUDE.md` was ignored — the file was checked out but Claude was
   never told to read it. The prompt now instructs `cat CLAUDE.md`
   first, and `Bash(cat CLAUDE.md)` is added to allowed tools (narrowed
   from the broader `cat:*` to avoid granting unrestricted file read
   access on the runner).

3. No silence threshold — Claude commented on every PR. The prompt now
   says "if there are no real issues, post nothing", which avoids
   empty-signal noise and saves CI minutes on clean PRs.

Also removed `**/*.md` from `paths-ignore` so that `CLAUDE.md` changes
are no longer silently excluded from triggering the reviewer — since
that file is the source of truth for the conventions being enforced.