### PR TITLE
ci: split build into unit-test and xcode-build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,14 @@ on:
       - '.github/workflows/claude-code-review.yml'
       - '.github/workflows/claude.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  unit-test:
     runs-on: macos-26
-    timeout-minutes: 30
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -44,5 +45,34 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-konan-v1-
 
-      - name: Build and test
-        run: ./gradlew build
+      - name: Run unit tests
+        run: ./gradlew iosSimulatorArm64Test
+
+  xcode-build:
+    needs: unit-test
+    runs-on: macos-26
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-v1-${{ hashFiles('**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-v1-
+
+      - name: Verify Xcode build
+        run: ./gradlew verifyXcodeBuild


### PR DESCRIPTION
Closes #31.

## Summary

- Split the single `build` job into `unit-test` (runs `./gradlew iosSimulatorArm64Test`) and `xcode-build` (`needs: unit-test`, runs `./gradlew verifyXcodeBuild`).
- Unit-test failures now surface in ~5 min instead of waiting for the full Kotlin/Native + Xcode chain. Failing PRs skip the Xcode job entirely (`skipped`, not `failed`), so no wasted runner time.
- Moved `concurrency` to workflow level so a new push cancels both jobs of the previous run as a unit.
- Tightened per-job `timeout-minutes` (15 / 20) now that each job has a narrower scope.

Local invocation parity confirmed: `./gradlew build` still runs the full chain because `verifyXcodeBuild` remains wired into `check` in `composeApp/build.gradle.kts`. Only CI changes.

## Option B (module split) — deferred

Issue #31 also floated extracting a `:domain` module so domain-only PRs could skip K/N + Compose entirely. I assessed it and recommend deferring:

- **Feasibility is fine.** The codebase splits cleanly — `ShoppingListViewModel` only uses the non-Compose `lifecycle-viewmodel` artifact, no SQLDelight yet, `AppDependencies` is trivial.
- **But the win is conditional.** Savings only materialise on domain-only PRs. With v0.1 focused on building screens, most PRs will touch UI anyway.
- **Real costs:** rewiring the iOS framework path that `iosApp/` Xcode project references, rehoming `FakeClock` for cross-module sharing, ongoing "which module?" decisions per feature, and most importantly **adding a JVM target to `:domain` would mean tests run on a platform we don't ship to** — a regression in test fidelity for the sake of CI speed.
- **Re-evaluation trigger:** revisit once there are ≥5 screens or CI metrics show >30% of PRs are domain-only.

## Test plan

- [x] `unit-test` job runs first and completes in ~5 min
- [x] `xcode-build` only starts after `unit-test` succeeds; total wall time within ~1 min of the previous baseline
- [ ] Manually verify fail-fast by breaking a unit test on a throwaway commit (skip on this PR)
- [x] `./gradlew build` still passes locally (already verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)