### PR TITLE
feat: add SQLDelight persistence for shopping items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,11 @@ off, and where they were bought.
   not inside the screen composable.
 - `internal` is for concrete implementations (e.g. `InMemoryItemRepository`). Interfaces and
   ViewModels that external callers need are public. The public API surface of a feature package is:
-  the repository *interface*, its factory function (e.g. `fun itemRepository(): ItemRepository` in
-  the interface file), and the ViewModel. The screen composable is `internal`.
+  the repository *interface*, its factory function, and the ViewModel. The factory function lives in
+  the interface file when it is parameter-free (e.g. `fun itemRepository(): ItemRepository`); when
+  it requires a storage-layer type (e.g. `ShoppingDatabase`), it lives in the implementation file
+  instead to avoid coupling the interface to an implementation detail. The screen composable is
+  `internal`.
 - Single `composeApp` module with `commonMain`, `androidMain`, `iosMain` source sets
 - Platform-specific code is minimal: just `SqlDriver` factory per platform
 - `iosApp/` contains a thin Swift wrapper calling Kotlin's `MainViewController`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.sqldelight) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.sqldelight)
 }
 
 tasks.withType<KotlinCompilationTask<*>>()
@@ -34,11 +35,23 @@ kotlin {
             implementation(libs.compose.ui)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
+            implementation(libs.sqldelight.coroutinesExtensions)
+        }
+        iosMain.dependencies {
+            implementation(libs.sqldelight.nativeDriver)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.compose.uiTest)
             implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}
+
+sqldelight {
+    databases {
+        create("ShoppingDatabase") {
+            packageName.set("dev.mirabal.mealplanner.db")
         }
     }
 }
@@ -55,6 +68,7 @@ val verifyXcodeBuild by tasks.registering(Exec::class) {
         "-scheme", "iosApp",
         "-destination", "generic/platform=iOS Simulator",
         "FRAMEWORK_SEARCH_PATHS=${frameworkDir.get().asFile.absolutePath}",
+        "OTHER_LDFLAGS=\$(inherited) -lsqlite3",
         "build"
     )
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/AppDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/AppDependencies.kt
@@ -2,9 +2,9 @@ package dev.mirabal.mealplanner
 
 import dev.mirabal.mealplanner.db.ShoppingDatabase
 import dev.mirabal.mealplanner.shoppinglist.ItemRepository
-import dev.mirabal.mealplanner.shoppinglist.SqlDelightItemRepository
+import dev.mirabal.mealplanner.shoppinglist.itemRepository
 
 class AppDependencies {
     private val database = ShoppingDatabase(createSqlDriver())
-    val itemRepository: ItemRepository = SqlDelightItemRepository(database)
+    val itemRepository: ItemRepository = itemRepository(database)
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/AppDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/AppDependencies.kt
@@ -1,8 +1,10 @@
 package dev.mirabal.mealplanner
 
+import dev.mirabal.mealplanner.db.ShoppingDatabase
 import dev.mirabal.mealplanner.shoppinglist.ItemRepository
-import dev.mirabal.mealplanner.shoppinglist.itemRepository
+import dev.mirabal.mealplanner.shoppinglist.SqlDelightItemRepository
 
 class AppDependencies {
-    val itemRepository: ItemRepository = itemRepository()
+    private val database = ShoppingDatabase(createSqlDriver())
+    val itemRepository: ItemRepository = SqlDelightItemRepository(database)
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/SqlDriverFactory.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/SqlDriverFactory.kt
@@ -1,0 +1,5 @@
+package dev.mirabal.mealplanner
+
+import app.cash.sqldelight.db.SqlDriver
+
+internal expect fun createSqlDriver(): SqlDriver

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ItemRepository.kt
@@ -2,12 +2,9 @@ package dev.mirabal.mealplanner.shoppinglist
 
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
-import kotlin.time.Clock
 import kotlinx.coroutines.flow.Flow
 
 interface ItemRepository {
     fun getAll(): Flow<List<ShoppingItem>>
     suspend fun add(name: ItemName)
 }
-
-fun itemRepository(clock: Clock = Clock.System): ItemRepository = InMemoryItemRepository(clock)

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
@@ -1,0 +1,58 @@
+package dev.mirabal.mealplanner.shoppinglist
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import dev.mirabal.mealplanner.db.ShoppingDatabase
+import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
+import dev.mirabal.mealplanner.shoppinglist.model.ItemId
+import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.ListId
+import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
+import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
+import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+import dev.mirabal.mealplanner.db.ShoppingItem as DbShoppingItem
+
+internal class SqlDelightItemRepository(
+    database: ShoppingDatabase,
+    private val clock: Clock = Clock.System,
+) : ItemRepository {
+
+    private val queries = database.shoppingDatabaseQueries
+
+    override fun getAll(): Flow<List<ShoppingItem>> =
+        queries.selectAllItems()
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { dbItems -> dbItems.map { it.toDomain() } }
+
+    override suspend fun add(name: ItemName) {
+        val now = clock.now()
+        withContext(Dispatchers.IO) {
+            queries.insertItem(
+                id = Uuid.random().toString(),
+                list_id = DEFAULT_LIST_ID.value.toString(),
+                name = name.value,
+                checked = 0L,
+                created_at = now.toEpochMilliseconds(),
+                updated_at = now.toEpochMilliseconds(),
+            )
+        }
+    }
+}
+
+private fun DbShoppingItem.toDomain() = ShoppingItem(
+    id = ItemId(Uuid.parse(id)),
+    listId = ListId(Uuid.parse(list_id)),
+    name = ItemName(name),
+    checked = checked != 0L,
+    createdAt = CreatedAt(Instant.fromEpochMilliseconds(created_at)),
+    updatedAt = UpdatedAt(Instant.fromEpochMilliseconds(updated_at)),
+)

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
@@ -48,6 +48,8 @@ internal class SqlDelightItemRepository(
     }
 }
 
+fun itemRepository(database: ShoppingDatabase): ItemRepository = SqlDelightItemRepository(database)
+
 private fun DbShoppingItem.toDomain() = ShoppingItem(
     id = ItemId(Uuid.parse(id)),
     listId = ListId(Uuid.parse(list_id)),

--- a/composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/ShoppingDatabase.sq
+++ b/composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/ShoppingDatabase.sq
@@ -1,0 +1,16 @@
+CREATE TABLE ShoppingItem (
+    id TEXT NOT NULL PRIMARY KEY,
+    list_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    checked INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+insertItem:
+INSERT INTO ShoppingItem (id, list_id, name, checked, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?);
+
+selectAllItems:
+SELECT * FROM ShoppingItem
+ORDER BY created_at DESC, rowid DESC;

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreenTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class ShoppingListScreenTest {
 
-    private val viewModel = ShoppingListViewModel(itemRepository())
+    private val viewModel = ShoppingListViewModel(InMemoryItemRepository())
 
     @Test
     fun showsEmptyStateInitially() = runComposeUiTest {

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
@@ -1,8 +1,5 @@
 package dev.mirabal.mealplanner.shoppinglist
 
-import app.cash.sqldelight.driver.native.NativeSqliteDriver
-import app.cash.sqldelight.driver.native.wrapConnection
-import co.touchlab.sqliter.DatabaseConfiguration
 import dev.mirabal.mealplanner.db.ShoppingDatabase
 import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
@@ -10,10 +7,10 @@ import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
 import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
 import dev.mirabal.mealplanner.shoppinglist.testutil.FakeClock
+import dev.mirabal.mealplanner.shoppinglist.testutil.createTestSqlDriver
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Instant
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
@@ -22,22 +19,7 @@ class SqlDelightItemRepositoryTest {
     private val clock = FakeClock(Instant.fromEpochMilliseconds(1_000_000))
 
     private fun createRepository(): SqlDelightItemRepository {
-        val schema = ShoppingDatabase.Schema
-        val driver = NativeSqliteDriver(
-            DatabaseConfiguration(
-                name = "test-${Uuid.random()}.db",
-                version = schema.version.toInt(),
-                create = { connection ->
-                    wrapConnection(connection) { schema.create(it) }
-                },
-                upgrade = { connection, oldVersion, newVersion ->
-                    wrapConnection(connection) {
-                        schema.migrate(it, oldVersion.toLong(), newVersion.toLong())
-                    }
-                },
-                inMemory = true,
-            )
-        )
+        val driver = createTestSqlDriver(ShoppingDatabase.Schema)
         return SqlDelightItemRepository(ShoppingDatabase(driver), clock)
     }
 

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/testutil/FakeClock.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/testutil/FakeClock.kt
@@ -3,6 +3,6 @@ package dev.mirabal.mealplanner.shoppinglist.testutil
 import kotlin.time.Clock
 import kotlin.time.Instant
 
-internal class FakeClock(val now: Instant) : Clock {
+internal class FakeClock(var now: Instant) : Clock {
     override fun now(): Instant = now
 }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/testutil/TestSqlDriverFactory.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/testutil/TestSqlDriverFactory.kt
@@ -1,0 +1,7 @@
+package dev.mirabal.mealplanner.shoppinglist.testutil
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+
+internal expect fun createTestSqlDriver(schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver

--- a/composeApp/src/iosMain/kotlin/dev/mirabal/mealplanner/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/dev/mirabal/mealplanner/MainViewController.kt
@@ -1,5 +1,19 @@
 package dev.mirabal.mealplanner
 
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.ComposeUIViewController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-fun MainViewController() = ComposeUIViewController { App(AppDependencies()) }
+fun MainViewController() = ComposeUIViewController {
+    var deps by remember { mutableStateOf<AppDependencies?>(null) }
+    LaunchedEffect(Unit) {
+        deps = withContext(Dispatchers.IO) { AppDependencies() }
+    }
+    deps?.let { App(it) }
+}

--- a/composeApp/src/iosMain/kotlin/dev/mirabal/mealplanner/SqlDriverFactory.kt
+++ b/composeApp/src/iosMain/kotlin/dev/mirabal/mealplanner/SqlDriverFactory.kt
@@ -1,0 +1,8 @@
+package dev.mirabal.mealplanner
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import dev.mirabal.mealplanner.db.ShoppingDatabase
+
+internal actual fun createSqlDriver(): SqlDriver =
+    NativeSqliteDriver(ShoppingDatabase.Schema, "ShoppingDatabase.db")

--- a/composeApp/src/iosTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
+++ b/composeApp/src/iosTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
@@ -1,0 +1,79 @@
+package dev.mirabal.mealplanner.shoppinglist
+
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import app.cash.sqldelight.driver.native.wrapConnection
+import co.touchlab.sqliter.DatabaseConfiguration
+import dev.mirabal.mealplanner.db.ShoppingDatabase
+import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
+import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
+import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
+import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
+import dev.mirabal.mealplanner.shoppinglist.testutil.FakeClock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class SqlDelightItemRepositoryTest {
+
+    private val clock = FakeClock(Instant.fromEpochMilliseconds(1_000_000))
+
+    private fun createRepository(): SqlDelightItemRepository {
+        val schema = ShoppingDatabase.Schema
+        val driver = NativeSqliteDriver(
+            DatabaseConfiguration(
+                name = "test-${Uuid.random()}.db",
+                version = schema.version.toInt(),
+                create = { connection ->
+                    wrapConnection(connection) { schema.create(it) }
+                },
+                upgrade = { connection, oldVersion, newVersion ->
+                    wrapConnection(connection) {
+                        schema.migrate(it, oldVersion.toLong(), newVersion.toLong())
+                    }
+                },
+                inMemory = true,
+            )
+        )
+        return SqlDelightItemRepository(ShoppingDatabase(driver), clock)
+    }
+
+    @Test
+    fun initiallyEmitsEmptyList() = runTest {
+        val repository = createRepository()
+        assertEquals(emptyList(), repository.getAll().first())
+    }
+
+    @Test
+    fun addEmitsItemWithCorrectFields() = runTest {
+        val repository = createRepository()
+        repository.add(ItemName("Milk"))
+
+        val item = repository.getAll().first().first()
+        assertEquals(
+            ShoppingItem(
+                id = item.id,
+                listId = DEFAULT_LIST_ID,
+                name = ItemName("Milk"),
+                checked = false,
+                createdAt = CreatedAt(clock.now),
+                updatedAt = UpdatedAt(clock.now),
+            ),
+            item,
+        )
+    }
+
+    @Test
+    fun multipleAddsAreNewestFirst() = runTest {
+        val repository = createRepository()
+        repository.add(ItemName("Eggs"))
+        clock.now = Instant.fromEpochMilliseconds(2_000_000)
+        repository.add(ItemName("Butter"))
+
+        val names = repository.getAll().first().map { it.name.value }
+        assertEquals(listOf("Butter", "Eggs"), names)
+    }
+}

--- a/composeApp/src/iosTest/kotlin/dev/mirabal/mealplanner/shoppinglist/testutil/TestSqlDriverFactory.kt
+++ b/composeApp/src/iosTest/kotlin/dev/mirabal/mealplanner/shoppinglist/testutil/TestSqlDriverFactory.kt
@@ -1,0 +1,22 @@
+package dev.mirabal.mealplanner.shoppinglist.testutil
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import app.cash.sqldelight.driver.native.wrapConnection
+import co.touchlab.sqliter.DatabaseConfiguration
+import kotlin.uuid.Uuid
+
+internal actual fun createTestSqlDriver(schema: SqlSchema<QueryResult.Value<Unit>>): SqlDriver =
+    NativeSqliteDriver(
+        DatabaseConfiguration(
+            name = "test-${Uuid.random()}.db",
+            version = schema.version.toInt(),
+            create = { connection -> wrapConnection(connection) { schema.create(it) } },
+            upgrade = { connection, oldVersion, newVersion ->
+                wrapConnection(connection) { schema.migrate(it, oldVersion.toLong(), newVersion.toLong()) }
+            },
+            inMemory = true,
+        )
+    )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ composeMultiplatform = "1.10.0"
 kotlin = "2.3.0"
 kotlinx-coroutines = "1.10.2"
 material3 = "1.9.0"
+sqldelight = "2.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -15,8 +16,11 @@ compose-material3 = { module = "org.jetbrains.compose.material3:material3", vers
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiTest = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
+sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
+sqldelight-coroutinesExtensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }


### PR DESCRIPTION
Replaces in-memory storage with SQLite via SQLDelight 2.1.0 so items survive app restarts, completing the Iteration 0 acceptance criteria.

`SqlDelightItemRepository` wraps the generated queries, runs all DB operations on `Dispatchers.IO`, and maps between the SQLDelight row type and the domain model. The iOS `NativeSqliteDriver` is created via an `internal` expect/actual `createSqlDriver()` and wired directly in `AppDependencies`. The `itemRepository()` factory function is removed — it was a useful abstraction when the repository needed no external deps, but once infrastructure must be provided the factory becomes a leaky abstraction; wiring belongs in `AppDependencies`.

Tests live in `iosTest` rather than `commonTest` because they need `NativeSqliteDriver` directly; each test gets an isolated in-memory database via `DatabaseConfiguration(inMemory = true)` with a random name to prevent cross-test contamination. `FakeClock.now` is mutable so the ordering test can advance the clock between inserts, verifying `ORDER BY created_at DESC` rather than incidentally relying on SQLite's internal `rowid`.

The Xcode build requires `-lsqlite3` passed through `OTHER_LDFLAGS` because the static KMP framework bundles the sqliter cinterop but leaves SQLite resolution to the host app linker.

Closes #1