### PR TITLE
feat: slice 1 — whole number quantities (no unit)

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepository.kt
@@ -3,6 +3,7 @@ package dev.mirabal.mealplanner.shoppinglist
 import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemId
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
 import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
@@ -21,13 +22,13 @@ internal class InMemoryItemRepository(
 
     override fun getAll(): Flow<List<ShoppingItem>> = items.asStateFlow()
 
-    override suspend fun add(name: ItemName) {
+    override suspend fun add(name: ItemName, quantity: Quantity?) {
         val now = clock.now()
         val item = ShoppingItem(
             id = ItemId(Uuid.random()),
             listId = DEFAULT_LIST_ID,
             name = name,
-            quantity = null,
+            quantity = quantity,
             checked = false,
             createdAt = CreatedAt(now),
             updatedAt = UpdatedAt(now),

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepository.kt
@@ -27,6 +27,7 @@ internal class InMemoryItemRepository(
             id = ItemId(Uuid.random()),
             listId = DEFAULT_LIST_ID,
             name = name,
+            quantity = null,
             checked = false,
             createdAt = CreatedAt(now),
             updatedAt = UpdatedAt(now),

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ItemRepository.kt
@@ -1,10 +1,11 @@
 package dev.mirabal.mealplanner.shoppinglist
 
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import kotlinx.coroutines.flow.Flow
 
 interface ItemRepository {
     fun getAll(): Flow<List<ShoppingItem>>
-    suspend fun add(name: ItemName)
+    suspend fun add(name: ItemName, quantity: Quantity? = null)
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -71,12 +70,8 @@ internal fun ShoppingListScreen(viewModel: ShoppingListViewModel) {
                     }
                 }
             }
-            items(items, key = { it.id.value.toString() }) { item ->
-                val label = when (val q = item.quantity) {
-                    is Quantity.WholeNumber -> "${q.value} ${item.name.value}"
-                    null -> item.name.value
-                }
-                ListItem(headlineContent = { Text(label) })
+            items(items, key = { it.id }) { item ->
+                ListItem(headlineContent = { Text(item.label) })
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
@@ -17,14 +19,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ShoppingListScreen(viewModel: ShoppingListViewModel) {
     val items by viewModel.items.collectAsStateWithLifecycle()
     val inputText by viewModel.inputText.collectAsStateWithLifecycle()
+    val quantityInput by viewModel.quantityInput.collectAsStateWithLifecycle()
+    val canAdd by viewModel.canAdd.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = { TopAppBar(title = { Text("Shopping List") }) }
@@ -47,9 +53,18 @@ internal fun ShoppingListScreen(viewModel: ShoppingListViewModel) {
                         modifier = Modifier.weight(1f),
                         placeholder = { Text("Item name") },
                     )
+                    OutlinedTextField(
+                        value = quantityInput,
+                        onValueChange = viewModel::onQuantityChanged,
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .width(80.dp),
+                        placeholder = { Text("Qty") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    )
                     Button(
                         onClick = viewModel::onAddClicked,
-                        enabled = inputText.isNotBlank(),
+                        enabled = canAdd,
                         modifier = Modifier.padding(start = 8.dp),
                     ) {
                         Text("Add")
@@ -57,7 +72,11 @@ internal fun ShoppingListScreen(viewModel: ShoppingListViewModel) {
                 }
             }
             items(items, key = { it.id.value.toString() }) { item ->
-                ListItem(headlineContent = { Text(item.name.value) })
+                val label = when (val q = item.quantity) {
+                    is Quantity.WholeNumber -> "${q.value} ${item.name.value}"
+                    null -> item.name.value
+                }
+                ListItem(headlineContent = { Text(label) })
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListUiItem.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListUiItem.kt
@@ -1,0 +1,6 @@
+package dev.mirabal.mealplanner.shoppinglist
+
+data class ShoppingListUiItem(
+    val id: String,
+    val label: String,
+)

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModel.kt
@@ -3,11 +3,13 @@ package dev.mirabal.mealplanner.shoppinglist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -21,16 +23,30 @@ class ShoppingListViewModel(
     private val _inputText = MutableStateFlow("")
     val inputText: StateFlow<String> = _inputText.asStateFlow()
 
+    private val _quantityInput = MutableStateFlow("")
+    val quantityInput: StateFlow<String> = _quantityInput.asStateFlow()
+
+    val canAdd: StateFlow<Boolean> = combine(_inputText, _quantityInput) { name, qty ->
+        name.isNotBlank() && (qty.isBlank() || Quantity.parse(qty) != null)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
+
     fun onInputChanged(text: String) {
         _inputText.value = text
+    }
+
+    fun onQuantityChanged(text: String) {
+        _quantityInput.value = text
     }
 
     fun onAddClicked() {
         val text = _inputText.value.trim()
         if (text.isEmpty()) return
+        val rawQuantity = _quantityInput.value
+        val quantity = if (rawQuantity.isBlank()) null else Quantity.parse(rawQuantity) ?: return
         viewModelScope.launch {
-            repository.add(ItemName(text))
+            repository.add(ItemName(text), quantity)
             _inputText.value = ""
+            _quantityInput.value = ""
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -17,7 +18,8 @@ class ShoppingListViewModel(
     private val repository: ItemRepository,
 ) : ViewModel() {
 
-    val items: StateFlow<List<ShoppingItem>> = repository.getAll()
+    val items: StateFlow<List<ShoppingListUiItem>> = repository.getAll()
+        .map { items -> items.map { it.toUiItem() } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
     private val _inputText = MutableStateFlow("")
@@ -50,3 +52,11 @@ class ShoppingListViewModel(
         }
     }
 }
+
+private fun ShoppingItem.toUiItem() = ShoppingListUiItem(
+    id = id.value.toString(),
+    label = when (val q = quantity) {
+        is Quantity.WholeNumber -> "${q.value} ${name.value}"
+        null -> name.value
+    },
+)

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
@@ -56,7 +56,7 @@ private fun DbShoppingItem.toDomain() = ShoppingItem(
     id = ItemId(Uuid.parse(id)),
     listId = ListId(Uuid.parse(list_id)),
     name = ItemName(name),
-    quantity = quantity?.let { Quantity.parse(it) },
+    quantity = quantity?.let { requireNotNull(Quantity.parse(it)) { "Unrecognised quantity in DB: $it" } },
     checked = checked != 0L,
     createdAt = CreatedAt(Instant.fromEpochMilliseconds(created_at)),
     updatedAt = UpdatedAt(Instant.fromEpochMilliseconds(updated_at)),

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
@@ -7,6 +7,7 @@ import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemId
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
 import dev.mirabal.mealplanner.shoppinglist.model.ListId
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
 import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
@@ -54,6 +55,7 @@ private fun DbShoppingItem.toDomain() = ShoppingItem(
     id = ItemId(Uuid.parse(id)),
     listId = ListId(Uuid.parse(list_id)),
     name = ItemName(name),
+    quantity = quantity?.let { Quantity.parse(it) },
     checked = checked != 0L,
     createdAt = CreatedAt(Instant.fromEpochMilliseconds(created_at)),
     updatedAt = UpdatedAt(Instant.fromEpochMilliseconds(updated_at)),

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
@@ -41,6 +41,7 @@ internal class SqlDelightItemRepository(
                 id = Uuid.random().toString(),
                 list_id = DEFAULT_LIST_ID.value.toString(),
                 name = name.value,
+                quantity = quantity?.serialize(),
                 checked = 0L,
                 created_at = now.toEpochMilliseconds(),
                 updated_at = now.toEpochMilliseconds(),

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepository.kt
@@ -34,7 +34,7 @@ internal class SqlDelightItemRepository(
             .mapToList(Dispatchers.IO)
             .map { dbItems -> dbItems.map { it.toDomain() } }
 
-    override suspend fun add(name: ItemName) {
+    override suspend fun add(name: ItemName, quantity: Quantity?) {
         val now = clock.now()
         withContext(Dispatchers.IO) {
             queries.insertItem(

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/Quantity.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/Quantity.kt
@@ -1,0 +1,10 @@
+package dev.mirabal.mealplanner.shoppinglist.model
+
+sealed interface Quantity {
+    fun serialize(): String
+
+    data class WholeNumber(val value: Int) : Quantity {
+        init { require(value > 0) }
+        override fun serialize(): String = value.toString()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/Quantity.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/Quantity.kt
@@ -7,4 +7,12 @@ sealed interface Quantity {
         init { require(value > 0) }
         override fun serialize(): String = value.toString()
     }
+
+    companion object {
+        fun parse(input: String): Quantity? {
+            val trimmed = input.trim()
+            if (trimmed.isEmpty()) return null
+            return trimmed.toIntOrNull()?.takeIf { it > 0 }?.let { WholeNumber(it) }
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/ShoppingItem.kt
+++ b/composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/ShoppingItem.kt
@@ -18,6 +18,7 @@ data class ShoppingItem(
     val id: ItemId,
     val listId: ListId,
     val name: ItemName,
+    val quantity: Quantity?,
     val checked: Boolean,
     val createdAt: CreatedAt,
     val updatedAt: UpdatedAt,

--- a/composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/2.sqm
+++ b/composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/2.sqm
@@ -1,3 +1,5 @@
+DROP TABLE ShoppingItem;
+
 CREATE TABLE ShoppingItem (
     id TEXT NOT NULL PRIMARY KEY,
     list_id TEXT NOT NULL,
@@ -7,11 +9,3 @@ CREATE TABLE ShoppingItem (
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
 );
-
-insertItem:
-INSERT INTO ShoppingItem (id, list_id, name, checked, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?);
-
-selectAllItems:
-SELECT * FROM ShoppingItem
-ORDER BY created_at DESC, rowid DESC;

--- a/composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/ShoppingDatabase.sq
+++ b/composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/ShoppingDatabase.sq
@@ -9,8 +9,8 @@ CREATE TABLE ShoppingItem (
 );
 
 insertItem:
-INSERT INTO ShoppingItem (id, list_id, name, checked, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?);
+INSERT INTO ShoppingItem (id, list_id, name, quantity, checked, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?);
 
 selectAllItems:
 SELECT * FROM ShoppingItem

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepositoryTest.kt
@@ -32,6 +32,7 @@ class InMemoryItemRepositoryTest {
                 id = item.id,
                 listId = DEFAULT_LIST_ID,
                 name = ItemName("Milk"),
+                quantity = null,
                 checked = false,
                 createdAt = CreatedAt(clock.now),
                 updatedAt = UpdatedAt(clock.now),

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/InMemoryItemRepositoryTest.kt
@@ -2,6 +2,7 @@ package dev.mirabal.mealplanner.shoppinglist
 
 import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
 import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
@@ -48,5 +49,13 @@ class InMemoryItemRepositoryTest {
 
         val names = repository.getAll().first().map { it.name.value }
         assertEquals(listOf("Butter", "Eggs"), names)
+    }
+
+    @Test
+    fun addWithQuantityStoresQuantity() = runTest {
+        repository.add(ItemName("Lemons"), Quantity.WholeNumber(3))
+
+        val item = repository.getAll().first().first()
+        assertEquals(Quantity.WholeNumber(3), item.quantity)
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreenTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreenTest.kt
@@ -51,4 +51,32 @@ class ShoppingListScreenTest {
         onNodeWithText("Add").performClick()
         onNodeWithText("Milk").assertExists()
     }
+
+    @Test
+    fun typeNameAndQuantityShowsFormattedItem() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ShoppingListScreen(viewModel)
+            }
+        }
+
+        onNodeWithText("Item name").performTextInput("Lemons")
+        onNodeWithText("Qty").performTextInput("3")
+        onNodeWithText("Add").assertIsEnabled()
+        onNodeWithText("Add").performClick()
+        onNodeWithText("3 Lemons").assertExists()
+    }
+
+    @Test
+    fun invalidQuantityDisablesAddButton() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ShoppingListScreen(viewModel)
+            }
+        }
+
+        onNodeWithText("Item name").performTextInput("Lemons")
+        onNodeWithText("Qty").performTextInput("abc")
+        onNodeWithText("Add").assertIsNotEnabled()
+    }
 }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModelTest.kt
@@ -62,6 +62,7 @@ class ShoppingListViewModelTest {
                 id = item.id,
                 listId = DEFAULT_LIST_ID,
                 name = ItemName("Milk"),
+                quantity = null,
                 checked = false,
                 createdAt = CreatedAt(clock.now),
                 updatedAt = UpdatedAt(clock.now),

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModelTest.kt
@@ -1,11 +1,6 @@
 package dev.mirabal.mealplanner.shoppinglist
 
-import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
-import dev.mirabal.mealplanner.shoppinglist.model.Quantity
-import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
-import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
-import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
 import dev.mirabal.mealplanner.shoppinglist.testutil.FakeClock
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -58,18 +53,7 @@ class ShoppingListViewModelTest {
         viewModel.onAddClicked()
 
         val item = viewModel.items.value.first()
-        assertEquals(
-            ShoppingItem(
-                id = item.id,
-                listId = DEFAULT_LIST_ID,
-                name = ItemName("Milk"),
-                quantity = null,
-                checked = false,
-                createdAt = CreatedAt(clock.now),
-                updatedAt = UpdatedAt(clock.now),
-            ),
-            item,
-        )
+        assertEquals(ShoppingListUiItem(id = item.id, label = "Milk"), item)
         assertEquals("", viewModel.inputText.value)
         assertEquals("", viewModel.quantityInput.value)
     }
@@ -89,8 +73,8 @@ class ShoppingListViewModelTest {
         viewModel.onInputChanged("Butter")
         viewModel.onAddClicked()
 
-        val names = viewModel.items.value.map { it.name.value }
-        assertEquals(listOf("Butter", "Eggs"), names)
+        val labels = viewModel.items.value.map { it.label }
+        assertEquals(listOf("Butter", "Eggs"), labels)
     }
 
     @Test
@@ -130,7 +114,7 @@ class ShoppingListViewModelTest {
         viewModel.onAddClicked()
 
         val item = viewModel.items.value.first()
-        assertEquals(Quantity.WholeNumber(3), item.quantity)
+        assertEquals(ShoppingListUiItem(id = item.id, label = "3 Lemons"), item)
         assertEquals("", viewModel.inputText.value)
         assertEquals("", viewModel.quantityInput.value)
     }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModelTest.kt
@@ -2,6 +2,7 @@ package dev.mirabal.mealplanner.shoppinglist
 
 import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
 import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
@@ -70,6 +71,7 @@ class ShoppingListViewModelTest {
             item,
         )
         assertEquals("", viewModel.inputText.value)
+        assertEquals("", viewModel.quantityInput.value)
     }
 
     @Test
@@ -89,5 +91,57 @@ class ShoppingListViewModelTest {
 
         val names = viewModel.items.value.map { it.name.value }
         assertEquals(listOf("Butter", "Eggs"), names)
+    }
+
+    @Test
+    fun initialCanAddIsFalse() = runTest(testDispatcher) {
+        viewModel.canAdd.launchIn(backgroundScope)
+        assertEquals(false, viewModel.canAdd.value)
+    }
+
+    @Test
+    fun canAddIsTrueWhenNameFilledAndQuantityBlank() = runTest(testDispatcher) {
+        viewModel.canAdd.launchIn(backgroundScope)
+        viewModel.onInputChanged("Milk")
+        assertEquals(true, viewModel.canAdd.value)
+    }
+
+    @Test
+    fun canAddIsFalseWhenQuantityInputIsInvalid() = runTest(testDispatcher) {
+        viewModel.canAdd.launchIn(backgroundScope)
+        viewModel.onInputChanged("Milk")
+        viewModel.onQuantityChanged("abc")
+        assertEquals(false, viewModel.canAdd.value)
+    }
+
+    @Test
+    fun canAddIsTrueWhenNameFilledAndQuantityValid() = runTest(testDispatcher) {
+        viewModel.canAdd.launchIn(backgroundScope)
+        viewModel.onInputChanged("Lemons")
+        viewModel.onQuantityChanged("3")
+        assertEquals(true, viewModel.canAdd.value)
+    }
+
+    @Test
+    fun onAddClickedWithQuantityStoresQuantityAndClearsFields() = runTest(testDispatcher) {
+        viewModel.items.launchIn(backgroundScope)
+        viewModel.onInputChanged("Lemons")
+        viewModel.onQuantityChanged("3")
+        viewModel.onAddClicked()
+
+        val item = viewModel.items.value.first()
+        assertEquals(Quantity.WholeNumber(3), item.quantity)
+        assertEquals("", viewModel.inputText.value)
+        assertEquals("", viewModel.quantityInput.value)
+    }
+
+    @Test
+    fun onAddClickedWithInvalidQuantityIsNoOp() = runTest(testDispatcher) {
+        viewModel.items.launchIn(backgroundScope)
+        viewModel.onInputChanged("Lemons")
+        viewModel.onQuantityChanged("abc")
+        viewModel.onAddClicked()
+
+        assertEquals(emptyList(), viewModel.items.value)
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
@@ -3,6 +3,7 @@ package dev.mirabal.mealplanner.shoppinglist
 import dev.mirabal.mealplanner.db.ShoppingDatabase
 import dev.mirabal.mealplanner.shoppinglist.model.CreatedAt
 import dev.mirabal.mealplanner.shoppinglist.model.ItemName
+import dev.mirabal.mealplanner.shoppinglist.model.Quantity
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem
 import dev.mirabal.mealplanner.shoppinglist.model.ShoppingItem.Companion.DEFAULT_LIST_ID
 import dev.mirabal.mealplanner.shoppinglist.model.UpdatedAt
@@ -58,5 +59,14 @@ class SqlDelightItemRepositoryTest {
 
         val names = repository.getAll().first().map { it.name.value }
         assertEquals(listOf("Butter", "Eggs"), names)
+    }
+
+    @Test
+    fun addWithQuantityPersistsAndRetrievesQuantity() = runTest {
+        val repository = createRepository()
+        repository.add(ItemName("Lemons"), Quantity.WholeNumber(3))
+
+        val item = repository.getAll().first().first()
+        assertEquals(Quantity.WholeNumber(3), item.quantity)
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/SqlDelightItemRepositoryTest.kt
@@ -40,6 +40,7 @@ class SqlDelightItemRepositoryTest {
                 id = item.id,
                 listId = DEFAULT_LIST_ID,
                 name = ItemName("Milk"),
+                quantity = null,
                 checked = false,
                 createdAt = CreatedAt(clock.now),
                 updatedAt = UpdatedAt(clock.now),

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/model/QuantityTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/model/QuantityTest.kt
@@ -1,0 +1,28 @@
+package dev.mirabal.mealplanner.shoppinglist.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class QuantityTest {
+
+    @Test
+    fun wholeNumberRequiresPositiveValue() {
+        assertFailsWith<IllegalArgumentException> { Quantity.WholeNumber(0) }
+    }
+
+    @Test
+    fun wholeNumberRejectsNegativeValue() {
+        assertFailsWith<IllegalArgumentException> { Quantity.WholeNumber(-1) }
+    }
+
+    @Test
+    fun wholeNumberStoresValue() {
+        assertEquals(3, Quantity.WholeNumber(3).value)
+    }
+
+    @Test
+    fun wholeNumberSerializesToString() {
+        assertEquals("3", Quantity.WholeNumber(3).serialize())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/model/QuantityTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/mirabal/mealplanner/shoppinglist/model/QuantityTest.kt
@@ -3,6 +3,7 @@ package dev.mirabal.mealplanner.shoppinglist.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class QuantityTest {
 
@@ -24,5 +25,40 @@ class QuantityTest {
     @Test
     fun wholeNumberSerializesToString() {
         assertEquals("3", Quantity.WholeNumber(3).serialize())
+    }
+
+    @Test
+    fun parsePositiveIntReturnsWholeNumber() {
+        assertEquals(Quantity.WholeNumber(3), Quantity.parse("3"))
+    }
+
+    @Test
+    fun parseTrimsWhitespace() {
+        assertEquals(Quantity.WholeNumber(3), Quantity.parse("  3  "))
+    }
+
+    @Test
+    fun parseZeroReturnsNull() {
+        assertNull(Quantity.parse("0"))
+    }
+
+    @Test
+    fun parseNegativeReturnsNull() {
+        assertNull(Quantity.parse("-1"))
+    }
+
+    @Test
+    fun parseEmptyStringReturnsNull() {
+        assertNull(Quantity.parse(""))
+    }
+
+    @Test
+    fun parseBlankStringReturnsNull() {
+        assertNull(Quantity.parse("   "))
+    }
+
+    @Test
+    fun parseNonNumericReturnsNull() {
+        assertNull(Quantity.parse("abc"))
     }
 }

--- a/docs/superpowers/specs/2026-04-24-quantity-and-units-design.md
+++ b/docs/superpowers/specs/2026-04-24-quantity-and-units-design.md
@@ -37,11 +37,11 @@ Each slice has its own implementation plan, written and executed sequentially.
 `composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/Quantity.kt`
 
 ```kotlin
-sealed class Quantity {
-    data class WholeNumber(val value: Int) : Quantity() {
+sealed interface Quantity {
+    data class WholeNumber(val value: Int) : Quantity {
         init { require(value > 0) }
     }
-    data class Fraction(val numerator: Int, val denominator: Int) : Quantity() {
+    data class Fraction(val numerator: Int, val denominator: Int) : Quantity {
         init {
             require(numerator > 0)
             require(denominator > 0)
@@ -54,7 +54,7 @@ sealed class Quantity {
             }
         }
     }
-    data class Decimal(val value: Double) : Quantity() {
+    data class Decimal(val value: Double) : Quantity {
         init { require(value > 0) }
         // 2dp enforced at parse time (count chars after '.' in raw string, not via float arithmetic)
     }

--- a/docs/superpowers/specs/2026-04-24-quantity-and-units-design.md
+++ b/docs/superpowers/specs/2026-04-24-quantity-and-units-design.md
@@ -1,0 +1,257 @@
+# Iteration 1 — Quantity and Units: Design
+
+## Context
+
+Issue #2 adds quantity and unit support to shopping items (e.g. "300g mince beef", "⅓ tsp
+cinnamon", "3 lemons"). The original spec was challenged and revised:
+
+- The `REAL` DB column is replaced with TEXT serialisation for exact fraction representation
+- `Unit` is renamed to `MeasurementUnit` to avoid a clash with Kotlin's built-in `Unit` type
+- The quantity model uses a sealed hierarchy instead of float-with-epsilon-detection
+- `piece` unit is dropped (not a common recipe unit)
+- Mixed numbers (e.g. 2⅓) are scoped to a dedicated final slice
+
+The feature is delivered as five vertical slices, each end-to-end and TDD'd with a commit per
+green step.
+
+---
+
+## Slices
+
+| # | Scope | New types |
+|---|---|---|
+| 1 | Whole number quantities, no unit | `WholeNumber` |
+| 2 | Units | `MeasurementUnit`, `ItemAmount` |
+| 3 | Fractions | `Fraction` |
+| 4 | Decimals | `Decimal` |
+| 5 | Mixed numbers (e.g. 2⅓) | Formatter extension only |
+
+Each slice has its own implementation plan, written and executed sequentially.
+
+---
+
+## Domain Model
+
+### `Quantity` sealed hierarchy
+
+`composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/Quantity.kt`
+
+```kotlin
+sealed class Quantity {
+    data class WholeNumber(val value: Int) : Quantity() {
+        init { require(value > 0) }
+    }
+    data class Fraction(val numerator: Int, val denominator: Int) : Quantity() {
+        init {
+            require(numerator > 0)
+            require(denominator > 0)
+            require(gcd(numerator, denominator) == 1) // must be pre-normalised via Fraction.of()
+        }
+        companion object {
+            fun of(numerator: Int, denominator: Int): Fraction {
+                val g = gcd(numerator, denominator)
+                return Fraction(numerator / g, denominator / g)
+            }
+        }
+    }
+    data class Decimal(val value: Double) : Quantity() {
+        init { require(value > 0) }
+        // 2dp enforced at parse time (count chars after '.' in raw string, not via float arithmetic)
+    }
+
+    companion object {
+        fun parse(input: String): Quantity?
+    }
+}
+```
+
+### Parser rules (applied in order)
+
+1. Contains `/` → parse as `numerator/denominator`, normalise via `Fraction.of()` → `Fraction`
+2. No decimal point, parses as positive `Int` → `WholeNumber`
+3. Parses as `Double` with ≤ 2dp AND `value * 4` is a whole number → `Fraction` via `Fraction.of()`
+   (e.g. `0.25→Fraction(1,4)`, `0.5→Fraction(1,2)`, `0.75→Fraction(3,4)`);
+   slices 1–4 only convert values where `0 < value < 1`;
+   slice 5 extends to values above 1 (e.g. `1.25→Fraction(5,4)`)
+4. Parses as `Double` with ≤ 2dp → `Decimal`
+5. Otherwise → `null`
+
+2dp enforcement uses the raw input string (count characters after `.`), not float arithmetic.
+
+### `MeasurementUnit`
+
+`composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/MeasurementUnit.kt`
+
+```kotlin
+value class MeasurementUnit(val value: String) {
+    init {
+        require(value == value.trim())
+        require(value.isNotEmpty())
+    }
+}
+```
+
+Predefined common units: `g`, `kg`, `ml`, `l`, `tsp`, `tbsp`, `cm`. Free text also accepted.
+
+### `ItemAmount`
+
+`composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/model/ItemAmount.kt`
+
+```kotlin
+data class ItemAmount(val quantity: Quantity, val unit: MeasurementUnit?)
+```
+
+A unit without a quantity is not representable. A quantity without a unit is valid (e.g. "3 lemons").
+
+### `ShoppingItem` change
+
+`val amount: ItemAmount?` added — `null` for name-only items (e.g. "bread").
+
+---
+
+## Persistence
+
+### Schema (version 2)
+
+`composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/ShoppingDatabase.sq`
+
+```sql
+CREATE TABLE ShoppingItem (
+    id TEXT NOT NULL PRIMARY KEY,
+    list_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    quantity TEXT,
+    unit TEXT,
+    checked INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+```
+
+Both `quantity` and `unit` are nullable. An item without quantity stores `NULL` in both.
+
+### Migration file
+
+`composeApp/src/commonMain/sqldelight/dev/mirabal/mealplanner/db/2.sqm`
+
+Destructive migration (dev mode — data is cleared, no row migration needed):
+
+```sql
+DROP TABLE ShoppingItem;
+CREATE TABLE ShoppingItem (
+    id TEXT NOT NULL PRIMARY KEY,
+    list_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    quantity TEXT,
+    unit TEXT,
+    checked INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+```
+
+### Updated queries
+
+```sql
+insertItem:
+INSERT INTO ShoppingItem (id, list_id, name, quantity, unit, checked, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+selectAllItems:
+SELECT id, list_id, name, quantity, unit, checked, created_at, updated_at
+FROM ShoppingItem ORDER BY created_at DESC, rowid DESC;
+```
+
+### TEXT serialisation
+
+| Kotlin type | DB value |
+|---|---|
+| `WholeNumber(3)` | `"3"` |
+| `Fraction(1,3)` | `"1/3"` |
+| `Decimal(1.5)` | `"1.5"` |
+| `null` | `NULL` |
+
+`Quantity.parse()` is reused for deserialisation — no separate DB-mapping logic.
+
+### Repository signature
+
+```kotlin
+interface ItemRepository {
+    fun getAll(): Flow<List<ShoppingItem>>
+    suspend fun add(name: ItemName, amount: ItemAmount?)
+}
+```
+
+---
+
+## Presentation
+
+### `QuantityFormatter`
+
+`composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/QuantityFormatter.kt`
+
+```kotlin
+fun formatItem(name: ItemName, amount: ItemAmount?): String
+```
+
+| Amount | Output |
+|---|---|
+| `null` | `"bread"` |
+| `WholeNumber(3), unit = null` | `"3 lemons"` |
+| `WholeNumber(300), MeasurementUnit("g")` | `"300g mince beef"` |
+| `Fraction(1,3), MeasurementUnit("tsp")` | `"⅓ tsp cinnamon"` |
+| `Decimal(1.5), MeasurementUnit("kg")` | `"1.5kg chicken"` |
+
+Vulgar fraction map (slice 3): `1/4→¼`, `1/2→½`, `3/4→¾`, `1/3→⅓`, `2/3→⅔`.
+Unknown fractions (e.g. `Fraction(5,7)`) fall back to `"numerator/denominator"` (e.g. `"5/7"`)
+until slice 5.
+
+Mixed number display (`Fraction(7,3)→2⅓`) is slice 5 only.
+
+### ViewModel additions
+
+`composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListViewModel.kt`
+
+```kotlin
+val quantityInput: StateFlow<String>
+val unitInput: StateFlow<String>
+fun onQuantityChanged(text: String)
+fun onUnitChanged(text: String)
+```
+
+`onAddClicked()` parses `quantityInput` via `Quantity.parse()` and builds `ItemAmount?`.
+
+Add button disabled if name is blank, or if quantity input is non-empty but `Quantity.parse()` returns `null`.
+
+### Screen changes
+
+`composeApp/src/commonMain/kotlin/dev/mirabal/mealplanner/shoppinglist/ShoppingListScreen.kt`
+
+Input row layout:
+```
+[ Name field (flex) ] [ Qty ] [ Unit ▼ ] [ Add ]
+```
+
+- **Qty**: `OutlinedTextField`, keyboard allows digits, `.`, `/`
+- **Unit**: `ExposedDropdownMenuBox` — shows predefined units, also editable for free text
+- All fields clear after successful add
+- List items display `formatItem(item.name, item.amount)` instead of just the name
+
+---
+
+## Files to create
+
+- `shoppinglist/model/Quantity.kt`
+- `shoppinglist/model/MeasurementUnit.kt`
+- `shoppinglist/model/ItemAmount.kt`
+- `shoppinglist/QuantityFormatter.kt`
+- `db/2.sqm`
+
+## Files to modify
+
+- `shoppinglist/model/ShoppingItem.kt` — add `amount: ItemAmount?`
+- `ShoppingDatabase.sq` — updated schema + queries
+- `shoppinglist/ItemRepository.kt` — updated `add` signature
+- `shoppinglist/SqlDelightItemRepository.kt` — serialise/deserialise `ItemAmount`
+- `shoppinglist/ShoppingListViewModel.kt` — quantity + unit input state
+- `shoppinglist/ShoppingListScreen.kt` — new input fields + updated item display


### PR DESCRIPTION
## Summary

- Adds `Quantity` sealed interface with `WholeNumber` variant, `serialize()`, and `Quantity.parse()` for whole-number input
- Extends `ShoppingItem` with `quantity: Quantity?`, updates SQLDelight schema to v2 with a `quantity TEXT` column and a destructive migration
- Wires quantity through `ItemRepository`, `SqlDelightItemRepository`, and `InMemoryItemRepository`
- Adds `quantityInput` state and `canAdd` (name non-blank AND quantity valid-or-empty) to `ShoppingListViewModel`
- Adds a Qty input field to `ShoppingListScreen`; list items display `"N name"` when a whole-number quantity is set

Closes #2 (slice 1 of 5).

## Test Plan

- [ ] `./gradlew iosSimulatorArm64Test` — all unit tests pass (QuantityTest, ShoppingItemTest, InMemoryItemRepositoryTest, SqlDelightItemRepositoryTest, ShoppingListViewModelTest, ShoppingListScreenTest)
- [ ] `./gradlew build` — full build including Xcode succeeds
- [ ] Add an item with no quantity → displays name only
- [ ] Add an item with a whole-number quantity → displays "3 lemons"
- [ ] Add button disabled while quantity field contains invalid input (e.g. "abc")
- [ ] All fields clear after successful add

🤖 Generated with [Claude Code](https://claude.com/claude-code)